### PR TITLE
fix: data directory creation by uncommenting mkdirSync in Codebase class

### DIFF
--- a/ingestion/src/process/prepare/codebase.ts
+++ b/ingestion/src/process/prepare/codebase.ts
@@ -40,7 +40,7 @@ export class Codebase {
    }
 
    private initializeDataDirectory(removeExisting = false): void {
-      this._dataDirName = "data" || uuid()
+      this._dataDirName = uuid()
       this._dataDirPath = path.resolve(this._path, this._dataDirName)
 
       /* Handle data directory */

--- a/ingestion/src/process/prepare/codebase.ts
+++ b/ingestion/src/process/prepare/codebase.ts
@@ -45,7 +45,7 @@ export class Codebase {
 
       /* Handle data directory */
       if (removeExisting && existsSync(this._dataDirPath)) rmSync(this._dataDirPath, { recursive: true })
-      // mkdirSync(this._dataDirPath)
+      mkdirSync(this._dataDirPath)
    }
 
    private prepareFilesMetadata() {

--- a/ingestion/src/process/prepare/codebase.ts
+++ b/ingestion/src/process/prepare/codebase.ts
@@ -44,8 +44,9 @@ export class Codebase {
       this._dataDirPath = path.resolve(this._path, this._dataDirName)
 
       /* Handle data directory */
-      if (removeExisting && existsSync(this._dataDirPath)) rmSync(this._dataDirPath, { recursive: true })
-      mkdirSync(this._dataDirPath)
+      const exists = existsSync(this._dataDirPath)
+      if (removeExisting && exists) rmSync(this._dataDirPath, { recursive: true })
+      if (!exists) mkdirSync(this._dataDirPath)
    }
 
    private prepareFilesMetadata() {


### PR DESCRIPTION
Fixes #20 

This pull request includes a change to the `initializeDataDirectory` method in the `Codebase` class to ensure the data directory name is always generated using `uuid`.

* [`ingestion/src/process/prepare/codebase.ts`](diffhunk://#diff-828c1150d0cc19c79f26588d9da31c337bb0650a27ab06a3aebe566b97fb7195L43-R48): Modified the `initializeDataDirectory` method to always use `uuid` for generating `_dataDirName` and uncommented the `mkdirSync` call to ensure the data directory is created.